### PR TITLE
Fix expiry window

### DIFF
--- a/aws-profile
+++ b/aws-profile
@@ -27,6 +27,7 @@ import botocore.session
 
 CACHE_DIR = os.path.expanduser(os.path.join('~', '.aws', 'aws-profile', 'cache'))
 EXPIRY_WINDOW_SECONDS = 900
+EXPIRY_GRACE_SECONDS = 300
 
 
 def parse_args(argv=sys.argv):
@@ -122,7 +123,7 @@ def get_creds_from_sts(key_path):
 def is_creds_valid(creds):
     end_time = parse(creds['expiration'])
     now = datetime.now(tzlocal())
-    return now <= end_time
+    return (end_time - now).total_seconds() > EXPIRY_GRACE_SECONDS
 
 
 def load_creds():

--- a/aws-profile
+++ b/aws-profile
@@ -103,7 +103,7 @@ def get_creds_from_sts(key_path):
     assumedRoleObject = sts_connection.assume_role(
         role_arn=config['role_arn'],
         role_session_name=role_session_name,
-        duration_seconds=900,
+        duration_seconds=EXPIRY_WINDOW_SECONDS,
     )
 
     creds = {


### PR DESCRIPTION
* Make aws-profile use the EXPIRY_WINDOW_SECONDS value when obtaining an STS token.

* Add a grace period to help with longer-running multi-call jobs (eg. terraform), so aws-profile will refresh an STS token if it is within EXPIRY_GRACE_SECONDS of expiry.