### PR TITLE
allows you to specify an MFA token

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # aws-profile
 Wrapper script to generate &amp; pass AWS AssumeRole keys to other scripts
 
-If the role you're switching to requires MFA, add
+If the role you're switching to requires MFA, add your MFA device arn  (e.g.)
 ```
-mfa = true
+mfa = arn:aws:iam::500000000000:mfa/simonvc
 ```
 
 to the relevent `~/.aws/config` block

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Wrapper script to generate &amp; pass AWS AssumeRole keys to other scripts
 
 If the role you're switching to requires MFA, add your MFA device arn  (e.g.)
 ```
-mfa = arn:aws:iam::500000000000:mfa/simonvc
+mfa_serial = arn:aws:iam::500000000000:mfa/simonvc
 ```
 
 to the relevent `~/.aws/config` block

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # aws-profile
 Wrapper script to generate &amp; pass AWS AssumeRole keys to other scripts
+
+If the role you're switching to requires MFA, add
+```
+mfa = true
+```
+
+to the relevent `~/.aws/config` block

--- a/aws-profile
+++ b/aws-profile
@@ -101,10 +101,14 @@ def get_creds_from_sts(key_path):
     if not role_session_name:
         role_session_name = 'AWS-Profile-session-%s' % (int(time.time()))
 
+    mfa_TOTP = raw_input("Enter the MFA code: ")
+
     assumedRoleObject = sts_connection.assume_role(
         role_arn=config['role_arn'],
         role_session_name=role_session_name,
         duration_seconds=EXPIRY_WINDOW_SECONDS,
+        mfa_serial_number="arn:aws:iam::540757378086:mfa/simonvc",
+        mfa_token=mfa_TOTP
     )
 
     creds = {

--- a/aws-profile
+++ b/aws-profile
@@ -101,14 +101,14 @@ def get_creds_from_sts(key_path):
     if not role_session_name:
         role_session_name = 'AWS-Profile-session-%s' % (int(time.time()))
 
-    if config.has_key('mfa') and config['mfa'] in ["y", "Y", "yes", "true", "True"]:
+    if config.has_key('mfa'):
         mfa_TOTP = raw_input("Enter the MFA code: ")
 
         assumedRoleObject = sts_connection.assume_role(
             role_arn=config['role_arn'],
             role_session_name=role_session_name,
             duration_seconds=EXPIRY_WINDOW_SECONDS,
-            mfa_serial_number="arn:aws:iam::540757378086:mfa/simonvc",
+            mfa_serial_number=config['mfa'],
             mfa_token=mfa_TOTP
         )
     else:

--- a/aws-profile
+++ b/aws-profile
@@ -101,7 +101,7 @@ def get_creds_from_sts(key_path):
     if not role_session_name:
         role_session_name = 'AWS-Profile-session-%s' % (int(time.time()))
 
-    if config.has_key('mfa'):
+    if config.has_key('mfa_serial'):
         mfa_TOTP = raw_input("Enter the MFA code: ")
 
         assumedRoleObject = sts_connection.assume_role(

--- a/aws-profile
+++ b/aws-profile
@@ -108,7 +108,7 @@ def get_creds_from_sts(key_path):
             role_arn=config['role_arn'],
             role_session_name=role_session_name,
             duration_seconds=EXPIRY_WINDOW_SECONDS,
-            mfa_serial_number=config['mfa'],
+            mfa_serial_number=config['mfa_serial'],
             mfa_token=mfa_TOTP
         )
     else:

--- a/aws-profile
+++ b/aws-profile
@@ -101,7 +101,7 @@ def get_creds_from_sts(key_path):
     if not role_session_name:
         role_session_name = 'AWS-Profile-session-%s' % (int(time.time()))
 
-    if config['mfa'] in ["y", "Y", "yes", "true", "True"]:
+    if config.has_key('mfa') and config['mfa'] in ["y", "Y", "yes", "true", "True"]:
         mfa_TOTP = raw_input("Enter the MFA code: ")
 
         assumedRoleObject = sts_connection.assume_role(

--- a/aws-profile
+++ b/aws-profile
@@ -101,15 +101,23 @@ def get_creds_from_sts(key_path):
     if not role_session_name:
         role_session_name = 'AWS-Profile-session-%s' % (int(time.time()))
 
-    mfa_TOTP = raw_input("Enter the MFA code: ")
+    if config['mfa'] in ["y", "Y", "yes", "true", "True"]:
+        mfa_TOTP = raw_input("Enter the MFA code: ")
 
-    assumedRoleObject = sts_connection.assume_role(
-        role_arn=config['role_arn'],
-        role_session_name=role_session_name,
-        duration_seconds=EXPIRY_WINDOW_SECONDS,
-        mfa_serial_number="arn:aws:iam::540757378086:mfa/simonvc",
-        mfa_token=mfa_TOTP
-    )
+        assumedRoleObject = sts_connection.assume_role(
+            role_arn=config['role_arn'],
+            role_session_name=role_session_name,
+            duration_seconds=EXPIRY_WINDOW_SECONDS,
+            mfa_serial_number="arn:aws:iam::540757378086:mfa/simonvc",
+            mfa_token=mfa_TOTP
+        )
+    else:
+        assumedRoleObject = sts_connection.assume_role(
+            role_arn=config['role_arn'],
+            role_session_name=role_session_name,
+            duration_seconds=EXPIRY_WINDOW_SECONDS,
+        )
+
 
     creds = {
         'access_key': assumedRoleObject.credentials.access_key,


### PR DESCRIPTION
This PR allows you to specify a MFA token id in ~/.aws/config 

You will then be prompted for an MFA token (a 6 digit number) when switching roles.